### PR TITLE
Enrich refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ sparesults = "0.3"
 spareval = "0.2"
 spargebra = "0.4"
 tempfile = {version = "3.25"}
+thiserror = "2.0"
 tokio = { version = "1.49", default-features = false, features = ["full"] }
 url = { version = "2.5", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ harness = false
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
+bzip2 = "0.6"
 clap = { version = "4.5" }
 clap-verbosity-flag = { version = "3.0", default-features = false, features = ["log"] }
 env_logger = { version = "0.11", default-features = false }
 exitcode = "1.1"
+flate2 = "1"
 hdt = { git = "https://github.com/DeciSym/hdt", default-features = false, features = ["nt", "sparql", "cache"], rev = "5adf1f716c3c713a51046b24651c825fa306c9e4" }
 http = { version = "1.4", optional = true }
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.5" }
 clap-verbosity-flag = { version = "3.0", default-features = false, features = ["log"] }
 env_logger = { version = "0.11", default-features = false }
 exitcode = "1.1"
-hdt = { git = "https://github.com/DeciSym/hdt", default-features = false, features = ["nt", "sparql"], branch = "perf-improv" }
+hdt = { git = "https://github.com/DeciSym/hdt", default-features = false, features = ["nt", "sparql", "cache"], rev = "5adf1f716c3c713a51046b24651c825fa306c9e4" }
 http = { version = "1.4", optional = true }
 log = "0.4"
 oxhttp = { version = "0.3", optional=true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
+async-trait = "0.1"
 bzip2 = "0.6"
 clap = { version = "4.5" }
 clap-verbosity-flag = { version = "3.0", default-features = false, features = ["log"] }

--- a/src/create.rs
+++ b/src/create.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
-use crate::enrich::Enricher;
+use crate::enrich::{EnrichCtx, EnrichOutcome, EnrichResult, Enricher};
 use crate::rdf2nt::ConvertResult;
 use crate::rdf2nt::OxRdfConvert;
 use crate::rdf2nt::Rdf2Nt;
@@ -13,6 +13,15 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::{Builder, NamedTempFile};
 
+/// Closure supplied by the caller that computes a stable `NamedNode`
+/// identifier for a given file path (typically a content-hash IRI). Passed
+/// into `files_to_rdf` so the enricher dispatch layer can hash each file
+/// exactly once and share the result with every enricher.
+///
+/// `Send + Sync` bounds let the closure live across await points when
+/// `files_to_rdf` is awaited from a multi-threaded Tokio runtime.
+pub type FileIdFn<'a> = &'a (dyn Fn(&str) -> EnrichResult<NamedNode> + Send + Sync);
+
 pub struct FilesToRdfResult {
     pub rdf_path: String,
     pub unhandled_files: Vec<String>,
@@ -22,7 +31,7 @@ pub struct FilesToRdfResult {
 }
 
 /// Creates a HDT file from RDF source
-pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, anyhow::Error> {
+pub async fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, anyhow::Error> {
     debug!("Creating HDT...");
     // creating a tempfile to hold all the contents of the rdf input files
     let mut tmp_file = Builder::new()
@@ -31,7 +40,18 @@ pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, an
         .tempfile()
         .map_err(|e| anyhow::anyhow!("Error creating temporary file: {:?}", e))?;
 
-    let result = files_to_rdf(data, &mut tmp_file, Arc::new(OxRdfConvert {}), &[], None)?;
+    // No enrichers are wired in this path, so the file_id closure is never
+    // invoked. A panic closure documents that expectation at the type level.
+    let file_id_fn: FileIdFn = &|_| unreachable!("no enrichers registered");
+    let result = files_to_rdf(
+        data,
+        &mut tmp_file,
+        Arc::new(OxRdfConvert {}),
+        &[],
+        None,
+        file_id_fn,
+    )
+    .await?;
     if !result.unhandled_files.is_empty() {
         for f in &result.unhandled_files {
             if !Path::new(f).exists() {
@@ -75,13 +95,18 @@ pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, an
 
 /// Converts a list of RDF files to NTriple RDF
 /// returns the name of the file containing combined NTriple RDF, the names of any unhandled files,
-/// and any files that should be preserved as blobs
-pub fn files_to_rdf(
+/// and any files that should be preserved as blobs.
+///
+/// `file_id_fn` is invoked exactly once per file that matches an enricher, so
+/// the produced `NamedNode` can be reused inside the enricher without
+/// re-hashing the file contents.
+pub async fn files_to_rdf(
     data: &[String],
     out_file: &mut NamedTempFile,
     converter: Arc<dyn Rdf2Nt>,
     enrichers: &[Box<dyn Enricher>],
-    pkg_id: Option<&NamedNode>,
+    root_id: Option<&NamedNode>,
+    file_id_fn: FileIdFn<'_>,
 ) -> anyhow::Result<FilesToRdfResult> {
     let mut nt_files = vec![];
     let mut files_to_convert = vec![];
@@ -104,20 +129,30 @@ pub fn files_to_rdf(
 
         if let Some(enricher) = matched_enricher {
             debug!("Enriching file: {file}");
-            let triples = enricher
-                .enrich(file, pkg_id)
+            let file_id = file_id_fn(file)
+                .map_err(|e| anyhow::anyhow!("Error computing file id for {file}: {e}"))?;
+            let ctx = EnrichCtx {
+                file_path: file,
+                file_id: &file_id,
+                root_id,
+            };
+            let outcome = enricher
+                .enrich(&ctx)
+                .await
                 .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
-            if triples.is_empty() {
-                // Enricher declined — let the generic converter handle the file.
-                debug!("Enricher produced no triples for {file}, routing to converter");
-                files_to_convert.push(file.clone());
-            } else {
-                for triple in &triples {
-                    writeln!(out_file, "{triple} .").map_err(|e| {
-                        anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
-                    })?;
+            match outcome {
+                EnrichOutcome::Declined => {
+                    debug!("Enricher declined {file}, routing to converter");
+                    files_to_convert.push(file.clone());
                 }
-                enriched_sources.push(file.clone());
+                EnrichOutcome::Triples(triples) => {
+                    for triple in &triples {
+                        writeln!(out_file, "{triple} .").map_err(|e| {
+                            anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
+                        })?;
+                    }
+                    enriched_sources.push(file.clone());
+                }
             }
         }
         // Check for triples, this is the preferred RDF format and no additional conversion is required
@@ -172,32 +207,36 @@ pub fn files_to_rdf(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enrich::{EnrichResult, Enricher};
+    use crate::enrich::{EnrichCtx, EnrichOutcome, EnrichResult, Enricher};
+    use async_trait::async_trait;
     use oxrdf::{NamedNode, Triple};
     use tempfile::Builder;
 
     struct MockEnricher;
 
+    #[async_trait]
     impl Enricher for MockEnricher {
         fn supported_extensions(&self) -> Vec<&str> {
             vec!["mock"]
         }
 
-        fn enrich(
-            &self,
-            _file_path: &str,
-            _pkg_id: Option<&NamedNode>,
-        ) -> EnrichResult<Vec<Triple>> {
-            Ok(vec![Triple::new(
+        async fn enrich(&self, _ctx: &EnrichCtx<'_>) -> EnrichResult<EnrichOutcome> {
+            Ok(EnrichOutcome::Triples(vec![Triple::new(
                 NamedNode::new("http://example.org/mock-subject")?,
                 NamedNode::new("http://example.org/type")?,
                 NamedNode::new("http://example.org/Mock")?,
-            )])
+            )]))
         }
     }
 
-    #[test]
-    fn test_files_to_rdf_with_mock_enricher() {
+    /// Returns a deterministic per-path id for tests, so the same path always
+    /// maps to the same `NamedNode`.
+    fn test_file_id(path: &str) -> EnrichResult<NamedNode> {
+        Ok(NamedNode::new(format!("http://example.org/file/{path}"))?)
+    }
+
+    #[tokio::test]
+    async fn test_files_to_rdf_with_mock_enricher() {
         let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
         let mock_path = tmp.path().to_str().unwrap().to_string();
 
@@ -206,16 +245,19 @@ mod tests {
             .append(true)
             .tempfile()
             .unwrap();
-        let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
+        let root_id = NamedNode::new("http://example.org/pkg1").unwrap();
         let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
 
         let result = files_to_rdf(
             std::slice::from_ref(&mock_path),
             &mut out_file,
             Arc::new(OxRdfConvert {}),
             &enrichers,
-            Some(&pkg_id),
+            Some(&root_id),
+            file_id_fn,
         )
+        .await
         .unwrap();
 
         assert_eq!(result.enriched_sources, vec![mock_path]);
@@ -223,8 +265,8 @@ mod tests {
         assert!(contents.contains("<http://example.org/Mock>"));
     }
 
-    #[test]
-    fn test_files_to_rdf_empty_enrichers_backward_compat() {
+    #[tokio::test]
+    async fn test_files_to_rdf_empty_enrichers_backward_compat() {
         let tmp = Builder::new().suffix(".nt").tempfile().unwrap();
         std::fs::write(
             tmp.path(),
@@ -238,6 +280,7 @@ mod tests {
             .append(true)
             .tempfile()
             .unwrap();
+        let file_id_fn: FileIdFn = &|_| unreachable!("no enrichers registered");
 
         let result = files_to_rdf(
             std::slice::from_ref(&nt_path),
@@ -245,7 +288,9 @@ mod tests {
             Arc::new(OxRdfConvert {}),
             &[],
             None,
+            file_id_fn,
         )
+        .await
         .unwrap();
 
         assert!(result.unhandled_files.is_empty());
@@ -254,8 +299,8 @@ mod tests {
         assert_eq!(result.rdf_path, nt_path);
     }
 
-    #[test]
-    fn test_files_to_rdf_mixed_enricher_and_rdf() {
+    #[tokio::test]
+    async fn test_files_to_rdf_mixed_enricher_and_rdf() {
         // Create a .mock file
         let mock_tmp = Builder::new().suffix(".mock").tempfile().unwrap();
         let mock_path = mock_tmp.path().to_str().unwrap().to_string();
@@ -274,16 +319,19 @@ mod tests {
             .append(true)
             .tempfile()
             .unwrap();
-        let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
+        let root_id = NamedNode::new("http://example.org/pkg1").unwrap();
         let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
 
         let result = files_to_rdf(
             &[mock_path.clone(), nt_path],
             &mut out_file,
             Arc::new(OxRdfConvert {}),
             &enrichers,
-            Some(&pkg_id),
+            Some(&root_id),
+            file_id_fn,
         )
+        .await
         .unwrap();
 
         assert_eq!(result.enriched_sources, vec![mock_path]);
@@ -292,8 +340,8 @@ mod tests {
         assert!(contents.contains("<http://example.org/o>"));
     }
 
-    #[test]
-    fn test_files_to_rdf_enricher_without_pkg_id() {
+    #[tokio::test]
+    async fn test_files_to_rdf_enricher_without_root_id() {
         let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
         let mock_path = tmp.path().to_str().unwrap().to_string();
 
@@ -303,6 +351,7 @@ mod tests {
             .tempfile()
             .unwrap();
         let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
 
         let result = files_to_rdf(
             std::slice::from_ref(&mock_path),
@@ -310,12 +359,65 @@ mod tests {
             Arc::new(OxRdfConvert {}),
             &enrichers,
             None,
+            file_id_fn,
         )
+        .await
         .unwrap();
 
         assert_eq!(result.enriched_sources, vec![mock_path]);
         assert!(result.unhandled_files.is_empty());
         let contents = std::fs::read_to_string(result.rdf_path).unwrap();
         assert!(contents.contains("<http://example.org/Mock>"));
+    }
+
+    struct DeclineEnricher;
+
+    #[async_trait]
+    impl Enricher for DeclineEnricher {
+        fn supported_extensions(&self) -> Vec<&str> {
+            vec!["mock"]
+        }
+
+        async fn enrich(&self, _ctx: &EnrichCtx<'_>) -> EnrichResult<EnrichOutcome> {
+            Ok(EnrichOutcome::Declined)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_files_to_rdf_enricher_declines_falls_through_to_converter() {
+        // Write an NT-shaped body into a .mock file. Because the enricher
+        // declines, the file is passed to the generic converter, which here
+        // is `OxRdfConvert`. That converter doesn't handle `.mock`, so the
+        // file lands in `unhandled_files` — demonstrating that decline does
+        // route to the fallback path.
+        let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+        )
+        .unwrap();
+        let mock_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(DeclineEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
+
+        let result = files_to_rdf(
+            std::slice::from_ref(&mock_path),
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            None,
+            file_id_fn,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.enriched_sources.is_empty());
+        assert_eq!(result.unhandled_files, vec![mock_path]);
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -5,6 +5,7 @@ use crate::enrich::{EnrichCtx, EnrichOutcome, EnrichResult, Enricher};
 use crate::rdf2nt::ConvertResult;
 use crate::rdf2nt::OxRdfConvert;
 use crate::rdf2nt::Rdf2Nt;
+use anyhow::Context;
 use log::*;
 use oxrdf::NamedNode;
 use std::fs::{self, File, OpenOptions};
@@ -22,6 +23,7 @@ use tempfile::{Builder, NamedTempFile};
 /// `files_to_rdf` is awaited from a multi-threaded Tokio runtime.
 pub type FileIdFn<'a> = &'a (dyn Fn(&str) -> EnrichResult<NamedNode> + Send + Sync);
 
+#[derive(Debug)]
 pub struct FilesToRdfResult {
     pub rdf_path: String,
     pub unhandled_files: Vec<String>,
@@ -129,8 +131,8 @@ pub async fn files_to_rdf(
 
         if let Some(enricher) = matched_enricher {
             debug!("Enriching file: {file}");
-            let file_id = file_id_fn(file)
-                .map_err(|e| anyhow::anyhow!("Error computing file id for {file}: {e}"))?;
+            let file_id =
+                file_id_fn(file).with_context(|| format!("error computing file id for {file}"))?;
             let ctx = EnrichCtx {
                 file_path: file,
                 file_id: &file_id,
@@ -139,7 +141,7 @@ pub async fn files_to_rdf(
             let outcome = enricher
                 .enrich(&ctx)
                 .await
-                .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
+                .with_context(|| format!("error enriching file {file}"))?;
             match outcome {
                 EnrichOutcome::Declined => {
                     debug!("Enricher declined {file}, routing to converter");
@@ -147,8 +149,8 @@ pub async fn files_to_rdf(
                 }
                 EnrichOutcome::Triples(triples) => {
                     for triple in &triples {
-                        writeln!(out_file, "{triple} .").map_err(|e| {
-                            anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
+                        writeln!(out_file, "{triple} .").with_context(|| {
+                            format!("error writing enriched triples for {file}")
                         })?;
                     }
                     enriched_sources.push(file.clone());
@@ -167,7 +169,7 @@ pub async fn files_to_rdf(
     let conv_res = if !files_to_convert.is_empty() {
         let r = converter
             .convert_to_nt(files_to_convert, out_file.as_file())
-            .map_err(|e| anyhow::anyhow!("Error converting file(s) to NT: {e}"))?;
+            .context("error converting file(s) to NT")?;
         unrecognized_files.extend(r.unhandled.clone());
         r
     } else {
@@ -178,12 +180,12 @@ pub async fn files_to_rdf(
     // inefficient when creating an HDT file from one large file
     if nt_files.len() > 1 || conv_res.converted != 0 || !enriched_sources.is_empty() {
         for nt_file in nt_files {
-            let source = File::open(&nt_file)
-                .map_err(|e| anyhow::anyhow!("Error opening file {:?}: {:?}", nt_file, e))?;
+            let source =
+                File::open(&nt_file).with_context(|| format!("error opening file {nt_file:?}"))?;
             let mut source_reader = BufReader::new(source);
 
             copy(&mut source_reader, out_file)
-                .map_err(|e| anyhow::anyhow!("Error copying file {:?}: {:?}", &nt_file, e))?;
+                .with_context(|| format!("error copying file {nt_file:?}"))?;
         }
     } else if nt_files.len() == 1 && conv_res.converted == 0 {
         return Ok(FilesToRdfResult {
@@ -207,7 +209,7 @@ pub async fn files_to_rdf(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enrich::{EnrichCtx, EnrichOutcome, EnrichResult, Enricher};
+    use crate::enrich::{EnrichCtx, EnrichError, EnrichOutcome, EnrichResult, Enricher};
     use async_trait::async_trait;
     use oxrdf::{NamedNode, Triple};
     use tempfile::Builder;
@@ -381,6 +383,64 @@ mod tests {
         async fn enrich(&self, _ctx: &EnrichCtx<'_>) -> EnrichResult<EnrichOutcome> {
             Ok(EnrichOutcome::Declined)
         }
+    }
+
+    struct FailingParseEnricher;
+
+    #[async_trait]
+    impl Enricher for FailingParseEnricher {
+        fn supported_extensions(&self) -> Vec<&str> {
+            vec!["mock"]
+        }
+
+        async fn enrich(&self, ctx: &EnrichCtx<'_>) -> EnrichResult<EnrichOutcome> {
+            Err(EnrichError::parse(ctx.file_path, "synthetic parse failure"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_files_to_rdf_preserves_enricher_error_source_chain() {
+        // Regression test for the stringification anti-pattern. The dispatcher
+        // must wrap `EnrichError` as the *source* of the returned
+        // `anyhow::Error` (not flatten it into the message), so callers can
+        // downcast to recover the typed variant.
+        let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        let mock_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(FailingParseEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
+
+        let err = files_to_rdf(
+            std::slice::from_ref(&mock_path),
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            None,
+            file_id_fn,
+        )
+        .await
+        .expect_err("FailingParseEnricher should propagate an error");
+
+        // The outer anyhow context must mention the file path.
+        assert!(
+            err.to_string().contains(&mock_path),
+            "context message missing file path: {err}"
+        );
+
+        // Crucial: the underlying EnrichError must be reachable via downcast.
+        let source = err
+            .chain()
+            .find_map(|e| e.downcast_ref::<EnrichError>())
+            .expect("EnrichError must survive as a source, not be stringified");
+        assert!(
+            matches!(source, EnrichError::Parse { .. }),
+            "expected EnrichError::Parse variant, got {source:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/create.rs
+++ b/src/create.rs
@@ -1,15 +1,23 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
+use crate::enrich::Enricher;
 use crate::rdf2nt::ConvertResult;
 use crate::rdf2nt::OxRdfConvert;
 use crate::rdf2nt::Rdf2Nt;
 use log::*;
+use oxrdf::NamedNode;
 use std::fs::{self, File, OpenOptions};
 use std::io::{copy, BufReader, BufWriter, Write};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::{Builder, NamedTempFile};
+
+pub struct FilesToRdfResult {
+    pub rdf_path: String,
+    pub unhandled_files: Vec<String>,
+    pub blob_files: Vec<String>,
+}
 
 /// Creates a HDT file from RDF source
 pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, anyhow::Error> {
@@ -21,23 +29,22 @@ pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, an
         .tempfile()
         .map_err(|e| anyhow::anyhow!("Error creating temporary file: {:?}", e))?;
 
-    let (combined_rdf_path, unknown_files) =
-        files_to_rdf(data, &mut tmp_file, Arc::new(OxRdfConvert {}))?;
-    if !unknown_files.is_empty() {
-        for f in &unknown_files {
+    let result = files_to_rdf(data, &mut tmp_file, Arc::new(OxRdfConvert {}), &[], None)?;
+    if !result.unhandled_files.is_empty() {
+        for f in &result.unhandled_files {
             if !Path::new(f).exists() {
                 error!("file {f:?} could not be found on local machine");
             }
         }
-        error!("unable to convert the following files: {unknown_files:?}");
+        error!("unable to convert the following files: {:?}", result.unhandled_files);
         error!("check 'de create --help' for list of supported file types");
         return Err(anyhow::anyhow!(
             "unsupported files detected: {:?}",
-            unknown_files
+            result.unhandled_files
         ));
     }
 
-    let new_hdt = hdt::Hdt::read_nt(Path::new(&combined_rdf_path))
+    let new_hdt = hdt::Hdt::read_nt(Path::new(&result.rdf_path))
         .map_err(|e| anyhow::anyhow!("Error converting combined RDF to HDT: {e}"))?;
 
     let out_file = OpenOptions::new()
@@ -62,15 +69,19 @@ pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, an
 }
 
 /// Converts a list of RDF files to NTriple RDF
-/// returns the name of the file containing combined NTriple RDF and the names of any unhandled files
+/// returns the name of the file containing combined NTriple RDF, the names of any unhandled files,
+/// and any files that should be preserved as blobs
 pub fn files_to_rdf(
     data: &[String],
     out_file: &mut NamedTempFile,
     converter: Arc<dyn Rdf2Nt>,
-) -> anyhow::Result<(String, Vec<String>), anyhow::Error> {
+    enrichers: &[Box<dyn Enricher>],
+    pkg_id: Option<&NamedNode>,
+) -> anyhow::Result<FilesToRdfResult> {
     let mut nt_files = vec![];
     let mut files_to_convert = vec![];
     let mut unrecognized_files = vec![];
+    let mut blob_files = vec![];
 
     for file in data.iter() {
         let path = Path::new(&file);
@@ -79,8 +90,32 @@ pub fn files_to_rdf(
             continue;
         }
 
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+
+        // Check if any enricher handles this extension
+        let matched_enricher = enrichers.iter().find(|e| {
+            e.supported_extensions().iter().any(|supported| *supported == ext)
+        });
+
+        if let Some(enricher) = matched_enricher {
+            if let Some(id) = pkg_id {
+                debug!("Enriching file: {file}");
+                let enrich_result = enricher
+                    .enrich(file, id, out_file)
+                    .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
+                if enrich_result.preserve_source_as_blob {
+                    blob_files.push(file.clone());
+                }
+            } else {
+                warn!("Enricher matched for {file} but no pkg_id provided, skipping enrichment");
+                unrecognized_files.push(file.clone());
+            }
+        }
         // Check for triples, this is the preferred RDF format and no additional conversion is required
-        if file.ends_with(".nt") {
+        else if file.ends_with(".nt") {
             debug!("Adding RDF triples to graph");
             nt_files.push(file.clone());
         } else {
@@ -100,7 +135,7 @@ pub fn files_to_rdf(
 
     // optimization attempt. If only one NTriple file provided don't do an additional file copy otherwise
     // inefficient when creating an HDT file from one large file
-    if nt_files.len() > 1 || conv_res.converted != 0 {
+    if nt_files.len() > 1 || conv_res.converted != 0 || !blob_files.is_empty() {
         for nt_file in nt_files {
             let source = File::open(&nt_file)
                 .map_err(|e| anyhow::anyhow!("Error opening file {:?}: {:?}", nt_file, e))?;
@@ -110,18 +145,137 @@ pub fn files_to_rdf(
                 .map_err(|e| anyhow::anyhow!("Error copying file {:?}: {:?}", &nt_file, e))?;
         }
     } else if nt_files.len() == 1 && conv_res.converted == 0 {
-        return Ok((nt_files[0].clone(), unrecognized_files));
+        return Ok(FilesToRdfResult {
+            rdf_path: nt_files[0].clone(),
+            unhandled_files: unrecognized_files,
+            blob_files,
+        });
     }
 
-    Ok((
-        out_file
+    Ok(FilesToRdfResult {
+        rdf_path: out_file
             .path()
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Invalid UTF-8 in temp file path"))?
             .to_string(),
-        unrecognized_files,
-    ))
+        unhandled_files: unrecognized_files,
+        blob_files,
+    })
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use crate::enrich::{EnrichResult, Enricher};
+    use oxrdf::NamedNode;
+    use std::io::Write;
+    use tempfile::Builder;
+
+    struct MockEnricher;
+
+    impl Enricher for MockEnricher {
+        fn supported_extensions(&self) -> Vec<&str> {
+            vec!["mock"]
+        }
+
+        fn enrich(
+            &self,
+            file_path: &str,
+            _pkg_id: &NamedNode,
+            output: &mut dyn Write,
+        ) -> Result<EnrichResult, Box<dyn std::error::Error>> {
+            writeln!(
+                output,
+                "<http://example.org/{}> <http://example.org/type> <http://example.org/Mock> .",
+                file_path.replace(' ', "_")
+            )?;
+            Ok(EnrichResult {
+                preserve_source_as_blob: true,
+            })
+        }
+    }
+
+    #[test]
+    fn test_files_to_rdf_with_mock_enricher() {
+        let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        let mock_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+        let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+
+        let result = files_to_rdf(
+            &[mock_path.clone()],
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            Some(&pkg_id),
+        )
+        .unwrap();
+
+        assert!(result.blob_files.contains(&mock_path));
+        let contents = std::fs::read_to_string(result.rdf_path).unwrap();
+        assert!(contents.contains("<http://example.org/Mock>"));
+    }
+
+    #[test]
+    fn test_files_to_rdf_empty_enrichers_backward_compat() {
+        let tmp = Builder::new().suffix(".nt").tempfile().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+        )
+        .unwrap();
+        let nt_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+
+        let result = files_to_rdf(
+            &[nt_path.clone()],
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &[],
+            None,
+        )
+        .unwrap();
+
+        assert!(result.unhandled_files.is_empty());
+        assert!(result.blob_files.is_empty());
+        // single NT file optimization: rdf_path should be the original file
+        assert_eq!(result.rdf_path, nt_path);
+    }
+
+    #[test]
+    fn test_files_to_rdf_mixed_enricher_and_rdf() {
+        // Create a .mock file
+        let mock_tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        let mock_path = mock_tmp.path().to_str().unwrap().to_string();
+
+        // Create an .nt file
+        let nt_tmp = Builder::new().suffix(".nt").tempfile().unwrap();
+        std::fs::write(
+            nt_tmp.path(),
+            "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+        )
+        .unwrap();
+        let nt_path = nt_tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+        let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+
+        let result = files_to_rdf(
+            &[mock_path.clone(), nt_path],
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            Some(&pkg_id),
+        )
+        .unwrap();
+
+        assert!(result.blob_files.contains(&mock_path));
+        let contents = std::fs::read_to_string(result.rdf_path).unwrap();
+        assert!(contents.contains("<http://example.org/Mock>"));
+        assert!(contents.contains("<http://example.org/o>"));
+    }
+}

--- a/src/create.rs
+++ b/src/create.rs
@@ -103,26 +103,21 @@ pub fn files_to_rdf(
             .find(|e| e.supported_extensions().contains(&ext));
 
         if let Some(enricher) = matched_enricher {
-            if let Some(id) = pkg_id {
-                debug!("Enriching file: {file}");
-                let triples = enricher
-                    .enrich(file, id)
-                    .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
-                if triples.is_empty() {
-                    // Enricher declined — let the generic converter handle the file.
-                    debug!("Enricher produced no triples for {file}, routing to converter");
-                    files_to_convert.push(file.clone());
-                } else {
-                    for triple in &triples {
-                        writeln!(out_file, "{triple} .").map_err(|e| {
-                            anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
-                        })?;
-                    }
-                    enriched_sources.push(file.clone());
-                }
+            debug!("Enriching file: {file}");
+            let triples = enricher
+                .enrich(file, pkg_id)
+                .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
+            if triples.is_empty() {
+                // Enricher declined — let the generic converter handle the file.
+                debug!("Enricher produced no triples for {file}, routing to converter");
+                files_to_convert.push(file.clone());
             } else {
-                warn!("Enricher matched for {file} but no pkg_id provided, skipping enrichment");
-                unrecognized_files.push(file.clone());
+                for triple in &triples {
+                    writeln!(out_file, "{triple} .").map_err(|e| {
+                        anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
+                    })?;
+                }
+                enriched_sources.push(file.clone());
             }
         }
         // Check for triples, this is the preferred RDF format and no additional conversion is required
@@ -188,7 +183,11 @@ mod tests {
             vec!["mock"]
         }
 
-        fn enrich(&self, _file_path: &str, _pkg_id: &NamedNode) -> EnrichResult<Vec<Triple>> {
+        fn enrich(
+            &self,
+            _file_path: &str,
+            _pkg_id: Option<&NamedNode>,
+        ) -> EnrichResult<Vec<Triple>> {
             Ok(vec![Triple::new(
                 NamedNode::new("http://example.org/mock-subject")?,
                 NamedNode::new("http://example.org/type")?,
@@ -291,5 +290,32 @@ mod tests {
         let contents = std::fs::read_to_string(result.rdf_path).unwrap();
         assert!(contents.contains("<http://example.org/Mock>"));
         assert!(contents.contains("<http://example.org/o>"));
+    }
+
+    #[test]
+    fn test_files_to_rdf_enricher_without_pkg_id() {
+        let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        let mock_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
+
+        let result = files_to_rdf(
+            std::slice::from_ref(&mock_path),
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.enriched_sources, vec![mock_path]);
+        assert!(result.unhandled_files.is_empty());
+        let contents = std::fs::read_to_string(result.rdf_path).unwrap();
+        assert!(contents.contains("<http://example.org/Mock>"));
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -110,6 +110,22 @@ pub async fn files_to_rdf(
     root_id: Option<&NamedNode>,
     file_id_fn: FileIdFn<'_>,
 ) -> anyhow::Result<FilesToRdfResult> {
+    // Reject ambiguous enricher configurations up front: a single extension
+    // claimed by more than one enricher is a caller bug. The previous
+    // Vec-order-wins dispatch silently masked this — here we fail explicitly
+    // so a misconfigured default set can't ship undetected.
+    let mut claimed: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (idx, enricher) in enrichers.iter().enumerate() {
+        for ext in enricher.supported_extensions() {
+            if let Some(prev_idx) = claimed.insert(ext, idx) {
+                return Err(anyhow::anyhow!(
+                    "ambiguous enricher configuration: extension \"{ext}\" \
+                     claimed by enrichers at positions {prev_idx} and {idx}"
+                ));
+            }
+        }
+    }
+
     let mut nt_files = vec![];
     let mut files_to_convert = vec![];
     let mut unrecognized_files = vec![];
@@ -440,6 +456,48 @@ mod tests {
         assert!(
             matches!(source, EnrichError::Parse { .. }),
             "expected EnrichError::Parse variant, got {source:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_files_to_rdf_rejects_duplicate_extension_claims() {
+        // Two enrichers both claim ".mock". Dispatch must refuse to proceed
+        // rather than let Vec ordering silently pick a winner.
+        let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
+        let mock_path = tmp.path().to_str().unwrap().to_string();
+
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
+        let enrichers: Vec<Box<dyn Enricher>> =
+            vec![Box::new(MockEnricher), Box::new(DeclineEnricher)];
+        let file_id_fn: FileIdFn = &test_file_id;
+
+        let err = files_to_rdf(
+            std::slice::from_ref(&mock_path),
+            &mut out_file,
+            Arc::new(OxRdfConvert {}),
+            &enrichers,
+            None,
+            file_id_fn,
+        )
+        .await
+        .expect_err("duplicate extension claim must be rejected");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ambiguous"),
+            "error should flag ambiguity: {msg}"
+        );
+        assert!(
+            msg.contains("mock"),
+            "error should name the conflicting extension: {msg}"
+        );
+        assert!(
+            msg.contains("0") && msg.contains("1"),
+            "error should point at both enricher positions: {msg}"
         );
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -16,7 +16,9 @@ use tempfile::{Builder, NamedTempFile};
 pub struct FilesToRdfResult {
     pub rdf_path: String,
     pub unhandled_files: Vec<String>,
-    pub blob_files: Vec<String>,
+    /// Source files that were handled by an enricher. Callers can apply their
+    /// own policy (e.g. preserve as a blob alongside the extracted triples).
+    pub enriched_sources: Vec<String>,
 }
 
 /// Creates a HDT file from RDF source
@@ -36,7 +38,10 @@ pub fn do_create(hdt_name: &str, data: &[String]) -> anyhow::Result<hdt::Hdt, an
                 error!("file {f:?} could not be found on local machine");
             }
         }
-        error!("unable to convert the following files: {:?}", result.unhandled_files);
+        error!(
+            "unable to convert the following files: {:?}",
+            result.unhandled_files
+        );
         error!("check 'de create --help' for list of supported file types");
         return Err(anyhow::anyhow!(
             "unsupported files detected: {:?}",
@@ -81,7 +86,7 @@ pub fn files_to_rdf(
     let mut nt_files = vec![];
     let mut files_to_convert = vec![];
     let mut unrecognized_files = vec![];
-    let mut blob_files = vec![];
+    let mut enriched_sources: Vec<String> = vec![];
 
     for file in data.iter() {
         let path = Path::new(&file);
@@ -90,24 +95,30 @@ pub fn files_to_rdf(
             continue;
         }
 
-        let ext = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
         // Check if any enricher handles this extension
-        let matched_enricher = enrichers.iter().find(|e| {
-            e.supported_extensions().iter().any(|supported| *supported == ext)
-        });
+        let matched_enricher = enrichers
+            .iter()
+            .find(|e| e.supported_extensions().contains(&ext));
 
         if let Some(enricher) = matched_enricher {
             if let Some(id) = pkg_id {
                 debug!("Enriching file: {file}");
-                let enrich_result = enricher
-                    .enrich(file, id, out_file)
+                let triples = enricher
+                    .enrich(file, id)
                     .map_err(|e| anyhow::anyhow!("Error enriching file {file}: {e}"))?;
-                if enrich_result.preserve_source_as_blob {
-                    blob_files.push(file.clone());
+                if triples.is_empty() {
+                    // Enricher declined — let the generic converter handle the file.
+                    debug!("Enricher produced no triples for {file}, routing to converter");
+                    files_to_convert.push(file.clone());
+                } else {
+                    for triple in &triples {
+                        writeln!(out_file, "{triple} .").map_err(|e| {
+                            anyhow::anyhow!("Error writing enriched triples for {file}: {e}")
+                        })?;
+                    }
+                    enriched_sources.push(file.clone());
                 }
             } else {
                 warn!("Enricher matched for {file} but no pkg_id provided, skipping enrichment");
@@ -135,7 +146,7 @@ pub fn files_to_rdf(
 
     // optimization attempt. If only one NTriple file provided don't do an additional file copy otherwise
     // inefficient when creating an HDT file from one large file
-    if nt_files.len() > 1 || conv_res.converted != 0 || !blob_files.is_empty() {
+    if nt_files.len() > 1 || conv_res.converted != 0 || !enriched_sources.is_empty() {
         for nt_file in nt_files {
             let source = File::open(&nt_file)
                 .map_err(|e| anyhow::anyhow!("Error opening file {:?}: {:?}", nt_file, e))?;
@@ -148,7 +159,7 @@ pub fn files_to_rdf(
         return Ok(FilesToRdfResult {
             rdf_path: nt_files[0].clone(),
             unhandled_files: unrecognized_files,
-            blob_files,
+            enriched_sources,
         });
     }
 
@@ -159,16 +170,15 @@ pub fn files_to_rdf(
             .ok_or_else(|| anyhow::anyhow!("Invalid UTF-8 in temp file path"))?
             .to_string(),
         unhandled_files: unrecognized_files,
-        blob_files,
+        enriched_sources,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enrich::{EnrichResult, Enricher};
-    use oxrdf::NamedNode;
-    use std::io::Write;
+    use crate::enrich::Enricher;
+    use oxrdf::{NamedNode, Triple};
     use tempfile::Builder;
 
     struct MockEnricher;
@@ -180,18 +190,14 @@ mod tests {
 
         fn enrich(
             &self,
-            file_path: &str,
+            _file_path: &str,
             _pkg_id: &NamedNode,
-            output: &mut dyn Write,
-        ) -> Result<EnrichResult, Box<dyn std::error::Error>> {
-            writeln!(
-                output,
-                "<http://example.org/{}> <http://example.org/type> <http://example.org/Mock> .",
-                file_path.replace(' ', "_")
-            )?;
-            Ok(EnrichResult {
-                preserve_source_as_blob: true,
-            })
+        ) -> Result<Vec<Triple>, Box<dyn std::error::Error>> {
+            Ok(vec![Triple::new(
+                NamedNode::new("http://example.org/mock-subject")?,
+                NamedNode::new("http://example.org/type")?,
+                NamedNode::new("http://example.org/Mock")?,
+            )])
         }
     }
 
@@ -200,12 +206,16 @@ mod tests {
         let tmp = Builder::new().suffix(".mock").tempfile().unwrap();
         let mock_path = tmp.path().to_str().unwrap().to_string();
 
-        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
         let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
         let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
 
         let result = files_to_rdf(
-            &[mock_path.clone()],
+            std::slice::from_ref(&mock_path),
             &mut out_file,
             Arc::new(OxRdfConvert {}),
             &enrichers,
@@ -213,7 +223,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result.blob_files.contains(&mock_path));
+        assert_eq!(result.enriched_sources, vec![mock_path]);
         let contents = std::fs::read_to_string(result.rdf_path).unwrap();
         assert!(contents.contains("<http://example.org/Mock>"));
     }
@@ -228,10 +238,14 @@ mod tests {
         .unwrap();
         let nt_path = tmp.path().to_str().unwrap().to_string();
 
-        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
 
         let result = files_to_rdf(
-            &[nt_path.clone()],
+            std::slice::from_ref(&nt_path),
             &mut out_file,
             Arc::new(OxRdfConvert {}),
             &[],
@@ -240,7 +254,7 @@ mod tests {
         .unwrap();
 
         assert!(result.unhandled_files.is_empty());
-        assert!(result.blob_files.is_empty());
+        assert!(result.enriched_sources.is_empty());
         // single NT file optimization: rdf_path should be the original file
         assert_eq!(result.rdf_path, nt_path);
     }
@@ -260,7 +274,11 @@ mod tests {
         .unwrap();
         let nt_path = nt_tmp.path().to_str().unwrap().to_string();
 
-        let mut out_file = Builder::new().suffix(".nt").append(true).tempfile().unwrap();
+        let mut out_file = Builder::new()
+            .suffix(".nt")
+            .append(true)
+            .tempfile()
+            .unwrap();
         let pkg_id = NamedNode::new("http://example.org/pkg1").unwrap();
         let enrichers: Vec<Box<dyn Enricher>> = vec![Box::new(MockEnricher)];
 
@@ -273,7 +291,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result.blob_files.contains(&mock_path));
+        assert_eq!(result.enriched_sources, vec![mock_path]);
         let contents = std::fs::read_to_string(result.rdf_path).unwrap();
         assert!(contents.contains("<http://example.org/Mock>"));
         assert!(contents.contains("<http://example.org/o>"));

--- a/src/create.rs
+++ b/src/create.rs
@@ -177,7 +177,7 @@ pub fn files_to_rdf(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enrich::Enricher;
+    use crate::enrich::{EnrichResult, Enricher};
     use oxrdf::{NamedNode, Triple};
     use tempfile::Builder;
 
@@ -188,11 +188,7 @@ mod tests {
             vec!["mock"]
         }
 
-        fn enrich(
-            &self,
-            _file_path: &str,
-            _pkg_id: &NamedNode,
-        ) -> Result<Vec<Triple>, Box<dyn std::error::Error>> {
+        fn enrich(&self, _file_path: &str, _pkg_id: &NamedNode) -> EnrichResult<Vec<Triple>> {
             Ok(vec![Triple::new(
                 NamedNode::new("http://example.org/mock-subject")?,
                 NamedNode::new("http://example.org/type")?,

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -62,5 +62,8 @@ impl EnrichError {
 
 pub trait Enricher: Send + Sync {
     fn supported_extensions(&self) -> Vec<&str>;
-    fn enrich(&self, file_path: &str, pkg_id: &NamedNode) -> EnrichResult<Vec<Triple>>;
+    /// Extract triples from `file_path`. When `pkg_id` is `None`, the enricher
+    /// may still produce triples (if it does not need a package identity) or
+    /// return an empty vec to let the caller fall back to generic conversion.
+    fn enrich(&self, file_path: &str, pkg_id: Option<&NamedNode>) -> EnrichResult<Vec<Triple>>;
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
+use async_trait::async_trait;
 use oxrdf::{IriParseError, NamedNode, Triple};
 
 #[derive(Debug, thiserror::Error)]
@@ -60,10 +61,50 @@ impl EnrichError {
     }
 }
 
+/// Result of invoking an [`Enricher`] on a single file.
+///
+/// The two variants disambiguate "enricher handled the file and produced these
+/// triples (possibly zero)" from "enricher saw the file and chose not to
+/// handle it". The caller uses the latter to fall through to a generic
+/// converter.
+#[derive(Debug)]
+pub enum EnrichOutcome {
+    /// The enricher handled the file. The inner `Vec` may be empty if the
+    /// file legitimately had nothing to extract (e.g. an OOXML archive with
+    /// no `docProps/core.xml`).
+    Triples(Vec<Triple>),
+    /// The enricher saw the file and declined to handle it (e.g. the content
+    /// was already the target RDF format). The caller should fall through to
+    /// generic conversion.
+    Declined,
+}
+
+/// Per-file context handed to [`Enricher::enrich`].
+///
+/// Grouping the parameters in a struct keeps the trait's signature stable as
+/// new optional inputs (limits, configuration, cancellation) are added.
+pub struct EnrichCtx<'a> {
+    /// Path to the source file on disk.
+    pub file_path: &'a str,
+    /// Stable identifier for this file (typically a content-hash IRI),
+    /// precomputed by the caller so enrichers don't re-hash the file.
+    pub file_id: &'a NamedNode,
+    /// Optional root/parent node that generated triples may be linked back
+    /// to — e.g. as the object of `dcterms:hasPart` on the file's own
+    /// subject, or as the subject in SBOM-style enrichers that emit
+    /// component information about the artifact. `None` means the enricher
+    /// should produce file-local triples only.
+    pub root_id: Option<&'a NamedNode>,
+}
+
+#[async_trait]
 pub trait Enricher: Send + Sync {
     fn supported_extensions(&self) -> Vec<&str>;
-    /// Extract triples from `file_path`. When `pkg_id` is `None`, the enricher
-    /// may still produce triples (if it does not need a package identity) or
-    /// return an empty vec to let the caller fall back to generic conversion.
-    fn enrich(&self, file_path: &str, pkg_id: Option<&NamedNode>) -> EnrichResult<Vec<Triple>>;
+    /// Extract triples from `ctx.file_path`.
+    ///
+    /// Return [`EnrichOutcome::Triples`] (possibly empty) when the file was
+    /// handled. Return [`EnrichOutcome::Declined`] to let the caller fall
+    /// through to the generic converter — typical when the file is already in
+    /// the target RDF format.
+    async fn enrich(&self, ctx: &EnrichCtx<'_>) -> EnrichResult<EnrichOutcome>;
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -1,13 +1,66 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
-use oxrdf::{NamedNode, Triple};
+use oxrdf::{IriParseError, NamedNode, Triple};
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EnrichError {
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error(transparent)]
+    InvalidIri(#[from] IriParseError),
+
+    #[error("unsupported content in {path}: {reason}")]
+    UnsupportedContent { path: String, reason: String },
+
+    #[error("parse error in {path}: {message}")]
+    Parse { path: String, message: String },
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+pub type EnrichResult<T> = Result<T, EnrichError>;
+
+impl EnrichError {
+    /// Attach a path to an `io::Error`.
+    pub fn io(path: impl Into<String>, source: std::io::Error) -> Self {
+        EnrichError::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    /// Record an unsupported-content condition.
+    pub fn unsupported(path: impl Into<String>, reason: impl Into<String>) -> Self {
+        EnrichError::UnsupportedContent {
+            path: path.into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Record a parse error.
+    pub fn parse(path: impl Into<String>, message: impl Into<String>) -> Self {
+        EnrichError::Parse {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Wrap a boxed error without `Send + Sync` bounds into the `Other` variant.
+    /// Used when calling helpers that return `Box<dyn std::error::Error>`.
+    pub fn from_boxed(e: Box<dyn std::error::Error>) -> Self {
+        EnrichError::Other(e.to_string().into())
+    }
+}
 
 pub trait Enricher: Send + Sync {
     fn supported_extensions(&self) -> Vec<&str>;
-    fn enrich(
-        &self,
-        file_path: &str,
-        pkg_id: &NamedNode,
-    ) -> Result<Vec<Triple>, Box<dyn std::error::Error>>;
+    fn enrich(&self, file_path: &str, pkg_id: &NamedNode) -> EnrichResult<Vec<Triple>>;
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -1,12 +1,7 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
-use oxrdf::NamedNode;
-use std::io::Write;
-
-pub struct EnrichResult {
-    pub preserve_source_as_blob: bool,
-}
+use oxrdf::{NamedNode, Triple};
 
 pub trait Enricher: Send + Sync {
     fn supported_extensions(&self) -> Vec<&str>;
@@ -14,6 +9,5 @@ pub trait Enricher: Send + Sync {
         &self,
         file_path: &str,
         pkg_id: &NamedNode,
-        output: &mut dyn Write,
-    ) -> Result<EnrichResult, Box<dyn std::error::Error>>;
+    ) -> Result<Vec<Triple>, Box<dyn std::error::Error>>;
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2025, Decisym, LLC
+// Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
+
+use oxrdf::NamedNode;
+use std::io::Write;
+
+pub struct EnrichResult {
+    pub preserve_source_as_blob: bool,
+}
+
+pub trait Enricher: Send + Sync {
+    fn supported_extensions(&self) -> Vec<&str>;
+    fn enrich(
+        &self,
+        file_path: &str,
+        pkg_id: &NamedNode,
+        output: &mut dyn Write,
+    ) -> Result<EnrichResult, Box<dyn std::error::Error>>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
 pub mod create;
+pub mod enrich;
 pub mod query;
 pub mod rdf2nt;
 #[cfg(feature = "server")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,10 +76,12 @@ async fn main() {
             sparql,
             output,
         } => query::do_query(data, sparql, output, &mut stdout_writer).await,
-        Commands::Create { output_name, data } => match create::do_create(output_name, data) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        },
+        Commands::Create { output_name, data } => {
+            match create::do_create(output_name, data).await {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e),
+            }
+        }
         Commands::View { data } => view::view_hdt(data, &mut stdout_writer),
         #[cfg(feature = "server")]
         Commands::Serve { location, bind } => de::serve::serve(location.to_owned(), bind),

--- a/src/query.rs
+++ b/src/query.rs
@@ -217,13 +217,19 @@ async fn handle_files(files: Vec<String>) -> (Vec<String>, Vec<String>, Option<a
         }
     }
 
+    // No enrichers are wired in this path, so the file_id closure is never
+    // invoked. A panic closure documents that expectation at the type level.
+    let file_id_fn: create::FileIdFn = &|_| unreachable!("no enrichers registered");
     let (combined_rdf_path, unknown_files) = match create::files_to_rdf(
         &files_to_convert,
         &mut rdf_tempfile,
         Arc::new(OxRdfConvert {}),
         &[],
         None,
-    ) {
+        file_id_fn,
+    )
+    .await
+    {
         Ok(result) => (result.rdf_path, result.unhandled_files),
         Err(e) => {
             return (

--- a/src/query.rs
+++ b/src/query.rs
@@ -221,8 +221,10 @@ async fn handle_files(files: Vec<String>) -> (Vec<String>, Vec<String>, Option<a
         &files_to_convert,
         &mut rdf_tempfile,
         Arc::new(OxRdfConvert {}),
+        &[],
+        None,
     ) {
-        Ok((p, u)) => (p, u),
+        Ok(result) => (result.rdf_path, result.unhandled_files),
         Err(e) => {
             return (
                 dir_path_vec,

--- a/src/rdf2nt.rs
+++ b/src/rdf2nt.rs
@@ -43,8 +43,11 @@ fn format_path_for(file: &Path) -> PathBuf {
 }
 
 /// Trait for different RDF libraries to implement for converting a list of files into NTriple RDF
-/// returns stats on converted data via ConvertResult
-pub trait Rdf2Nt {
+/// returns stats on converted data via ConvertResult.
+///
+/// `Send + Sync` bounds let `Arc<dyn Rdf2Nt>` live across await points inside
+/// the async `files_to_rdf` dispatcher.
+pub trait Rdf2Nt: Send + Sync {
     fn convert_to_nt(
         &self,
         file_paths: Vec<String>,
@@ -164,10 +167,8 @@ mod tests {
         enc.finish()?;
 
         let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        let res = OxRdfConvert {}.convert_to_nt(
-            vec![gz_path.to_string_lossy().into_owned()],
-            &out.reopen()?,
-        )?;
+        let res = OxRdfConvert {}
+            .convert_to_nt(vec![gz_path.to_string_lossy().into_owned()], &out.reopen()?)?;
         assert_eq!(res.converted, 1);
         assert!(res.unhandled.is_empty());
         assert_eq!(count_triples_in(&out), APPLE_TRIPLES);
@@ -185,10 +186,8 @@ mod tests {
         enc.finish()?;
 
         let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
-        let res = OxRdfConvert {}.convert_to_nt(
-            vec![bz_path.to_string_lossy().into_owned()],
-            &out.reopen()?,
-        )?;
+        let res = OxRdfConvert {}
+            .convert_to_nt(vec![bz_path.to_string_lossy().into_owned()], &out.reopen()?)?;
         assert_eq!(res.converted, 1);
         assert!(res.unhandled.is_empty());
         assert_eq!(count_triples_in(&out), APPLE_TRIPLES);

--- a/src/rdf2nt.rs
+++ b/src/rdf2nt.rs
@@ -1,14 +1,46 @@
 // Copyright (c) 2025, Decisym, LLC
 // Licensed under the BSD 3-Clause License (see LICENSE file in the project root).
 
+use bzip2::bufread::MultiBzDecoder;
+use flate2::bufread::MultiGzDecoder;
 use log::{debug, error, warn};
 use oxrdf::GraphName::DefaultGraph;
 use oxrdf::TripleRef;
 use oxrdfio::RdfFormat::{self, NTriples};
 use oxrdfio::RdfSerializer;
 use oxrdfio::{RdfParseError, RdfParser};
-use std::io::{BufReader, BufWriter, Write};
-use std::path::Path;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+const IO_BUF: usize = 1 << 20;
+
+/// Open `file` for reading, transparently decoding `.gz` and `.bz2` wrappers.
+fn open_rdf_reader(file: &Path) -> io::Result<Box<dyn Read>> {
+    let fp = File::open(file)?;
+    let buffered = BufReader::with_capacity(IO_BUF, fp);
+    match file.extension().and_then(|e| e.to_str()) {
+        Some(e) if e.eq_ignore_ascii_case("gz") => Ok(Box::new(BufReader::with_capacity(
+            IO_BUF,
+            MultiGzDecoder::new(buffered),
+        ))),
+        Some(e) if e.eq_ignore_ascii_case("bz2") => Ok(Box::new(BufReader::with_capacity(
+            IO_BUF,
+            MultiBzDecoder::new(buffered),
+        ))),
+        _ => Ok(Box::new(buffered)),
+    }
+}
+
+/// Strip a trailing `.gz`/`.bz2` so the inner RDF extension drives format detection.
+fn format_path_for(file: &Path) -> PathBuf {
+    match file.extension().and_then(|e| e.to_str()) {
+        Some(e) if e.eq_ignore_ascii_case("gz") || e.eq_ignore_ascii_case("bz2") => {
+            file.with_extension("")
+        }
+        _ => file.to_path_buf(),
+    }
+}
 
 /// Trait for different RDF libraries to implement for converting a list of files into NTriple RDF
 /// returns stats on converted data via ConvertResult
@@ -39,28 +71,27 @@ impl Rdf2Nt for OxRdfConvert {
         let mut res = ConvertResult::default();
         let mut dest_writer = BufWriter::new(output_file);
         for file in &file_paths {
-            let source = std::fs::File::open(file)
+            let path = Path::new(file);
+            let source_reader = open_rdf_reader(path)
                 .map_err(|e| anyhow::anyhow!("Error opening file {:?}: {:?}", file, e))?;
-            let source_reader = BufReader::new(source);
 
             debug!("converting {} to nt format", &file);
 
             let mut serializer =
                 RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
             let v = std::time::Instant::now();
-            let rdf_format = match Path::new(&file)
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .and_then(RdfFormat::from_extension)
-            {
-                Some(format) => format,
-                None if file.ends_with(".owl") => {
-                    // OWL files should be in XML format: https://www.w3.org/TR/owl-xmlsyntax/
-                    RdfFormat::RdfXml
-                }
-                None => {
-                    res.unhandled.push(file.to_string());
-                    continue;
+            let fmt_path = format_path_for(path);
+            let fmt_ext = fmt_path.extension().and_then(|ext| ext.to_str());
+            let rdf_format = if fmt_ext.is_some_and(|e| e.eq_ignore_ascii_case("owl")) {
+                // OWL files should be in XML format: https://www.w3.org/TR/owl-xmlsyntax/
+                RdfFormat::RdfXml
+            } else {
+                match fmt_ext.and_then(RdfFormat::from_extension) {
+                    Some(format) => format,
+                    None => {
+                        res.unhandled.push(file.to_string());
+                        continue;
+                    }
                 }
             };
             // TODO oxrdfio does offer split_file_for_parallel_parsing() which greatly improves performance, but only available for NT or NQ formats
@@ -102,5 +133,65 @@ impl Rdf2Nt for OxRdfConvert {
         }
         dest_writer.flush()?;
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const APPLE_TTL: &str = "tests/resources/apple.ttl";
+    const APPLE_TRIPLES: usize = 9;
+
+    fn count_triples_in(nt_file: &tempfile::NamedTempFile) -> usize {
+        let reader = BufReader::new(nt_file.reopen().expect("reopen tmp nt"));
+        RdfParser::from_format(NTriples)
+            .for_reader(reader)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("parse nt")
+            .len()
+    }
+
+    #[test]
+    fn gzipped_ttl_input() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let gz_path = tmp.path().join("apple.ttl.gz");
+        let source = std::fs::read(APPLE_TTL)?;
+        let mut enc =
+            flate2::write::GzEncoder::new(File::create(&gz_path)?, flate2::Compression::default());
+        enc.write_all(&source)?;
+        enc.finish()?;
+
+        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        let res = OxRdfConvert {}.convert_to_nt(
+            vec![gz_path.to_string_lossy().into_owned()],
+            &out.reopen()?,
+        )?;
+        assert_eq!(res.converted, 1);
+        assert!(res.unhandled.is_empty());
+        assert_eq!(count_triples_in(&out), APPLE_TRIPLES);
+        Ok(())
+    }
+
+    #[test]
+    fn bzipped_ttl_input() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let bz_path = tmp.path().join("apple.ttl.bz2");
+        let source = std::fs::read(APPLE_TTL)?;
+        let mut enc =
+            bzip2::write::BzEncoder::new(File::create(&bz_path)?, bzip2::Compression::default());
+        enc.write_all(&source)?;
+        enc.finish()?;
+
+        let out = tempfile::Builder::new().suffix(".nt").tempfile()?;
+        let res = OxRdfConvert {}.convert_to_nt(
+            vec![bz_path.to_string_lossy().into_owned()],
+            &out.reopen()?,
+        )?;
+        assert_eq!(res.converted, 1);
+        assert!(res.unhandled.is_empty());
+        assert_eq!(count_triples_in(&out), APPLE_TRIPLES);
+        Ok(())
     }
 }

--- a/src/sparql.rs
+++ b/src/sparql.rs
@@ -104,7 +104,7 @@ impl AggregateHdt {
             .map(
                 |(graph_name, path)| -> anyhow::Result<(String, hdt::hdt::HdtHybrid)> {
                     // let mut reader = BufReader::new(std::fs::File::open(path)?);
-                    let hdt = hdt::Hdt::new_hybrid_cache(path, true).map_err(|e| {
+                    let hdt = hdt::Hdt::new_hybrid_cache(path).map_err(|e| {
                         anyhow::anyhow!("Failed to load HDT from {:?}: {}", path, e)
                     })?;
                     Ok((graph_name.clone(), hdt))
@@ -334,7 +334,7 @@ impl AggregateHdt {
         let mut result = Vec::new();
         for (graph_name, path) in file_paths.iter() {
             // Create HDT instance for this file
-            if let Ok(hdt) = hdt::hdt::Hdt::new_hybrid_cache(path, true) {
+            if let Ok(hdt) = hdt::hdt::Hdt::new_hybrid_cache(path) {
                 for triple in hdt.triples_all() {
                     result.push((graph_name.clone(), triple));
                 }

--- a/tests/test-commands.rs
+++ b/tests/test-commands.rs
@@ -24,8 +24,8 @@ mod integration {
         Ok(String::from_utf8_lossy(&buffer).to_string())
     }
 
-    #[test]
-    fn test_do_create_rdf() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_do_create_rdf() -> anyhow::Result<()> {
         let tmp_dir: tempfile::TempDir = match tempdir() {
             Ok(d) => d,
             Err(e) => {
@@ -39,6 +39,7 @@ mod integration {
 
         assert!(
             create::do_create(&new_hdt.clone(), &["tests/resources/apple.ttl".to_string()],)
+                .await
                 .is_ok()
         );
         assert!(Path::new(&new_hdt).exists());
@@ -46,8 +47,8 @@ mod integration {
         Ok(())
     }
 
-    #[test]
-    fn test_view() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_view() -> anyhow::Result<()> {
         let tmp_dir: tempfile::TempDir = match tempdir() {
             Ok(d) => d,
             Err(e) => {
@@ -61,6 +62,7 @@ mod integration {
 
         assert!(
             create::do_create(&new_hdt.clone(), &["tests/resources/apple.ttl".to_string()],)
+                .await
                 .is_ok()
         );
         assert!(Path::new(&new_hdt).exists());
@@ -86,6 +88,7 @@ mod integration {
 
         assert!(
             create::do_create(&new_hdt.clone(), &["tests/resources/banana.nt".to_string()],)
+                .await
                 .is_ok()
         );
 
@@ -128,6 +131,7 @@ http://example.org/Banana"#
             &new_hdt.clone(),
             &["tests/resources/banana.ttl".to_string()],
         )
+        .await
         .is_ok());
 
         let data_files = vec![new_hdt];
@@ -168,6 +172,7 @@ http://example.org/Banana"#
             &pineapple_hdt.clone(),
             &["tests/resources/pineapple.ttl".to_string()],
         )
+        .await
         .is_ok());
 
         let data_files = vec![pineapple_hdt];
@@ -272,6 +277,7 @@ http://example.org/Pineapple,yellow"#
                 "tests/resources/banana.ttl".to_string()
             ],
         )
+        .await
         .is_ok());
 
         let data_files = vec![new_hdt];
@@ -346,7 +352,9 @@ http://example.org/Banana"#
                 d.replace(".ttl", ".hdt")
             );
             assert!(
-                create::do_create(&new_hdt.clone(), &[format!("tests/resources/{d}")],).is_ok()
+                create::do_create(&new_hdt.clone(), &[format!("tests/resources/{d}")],)
+                    .await
+                    .is_ok()
             );
             pkgs.push(new_hdt.clone());
         }

--- a/tests/test-server.rs
+++ b/tests/test-server.rs
@@ -10,7 +10,7 @@ mod server_tests {
     use tempfile::tempdir;
 
     // Helper to create test HDT files
-    fn setup_test_store() -> anyhow::Result<(tempfile::TempDir, AggregateHdt)> {
+    async fn setup_test_store() -> anyhow::Result<(tempfile::TempDir, AggregateHdt)> {
         let tmp_dir = tempdir()?;
 
         // Create a test HDT from banana.ttl
@@ -18,14 +18,16 @@ mod server_tests {
         de::create::do_create(
             banana_hdt.to_str().unwrap(),
             &["tests/resources/banana.ttl".to_string()],
-        )?;
+        )
+        .await?;
 
         // Create a test HDT from pineapple.ttl
         let pineapple_hdt = tmp_dir.path().join("pineapple.hdt");
         de::create::do_create(
             pineapple_hdt.to_str().unwrap(),
             &["tests/resources/pineapple.ttl".to_string()],
-        )?;
+        )
+        .await?;
 
         // Create AggregateHdt store
         let store = AggregateHdt::new(&[
@@ -51,9 +53,9 @@ mod server_tests {
         result.map_err(|(status, msg)| anyhow::anyhow!("HTTP Error {}: {}", status, msg))
     }
 
-    #[test]
-    fn test_sparql_query_post() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_sparql_query_post() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test SPARQL query via POST
         let query = "PREFIX ex: <http://example.org/> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> SELECT ?fruit WHERE { ?fruit rdf:type ex:Fruit }";
@@ -80,9 +82,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_sparql_query_ask() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_sparql_query_ask() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test ASK query
         let query = "PREFIX ex: <http://example.org/> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ASK { ?fruit rdf:type ex:Fruit }";
@@ -109,9 +111,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_sparql_query_service_description() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_sparql_query_service_description() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test GET to /query without query parameter (should return service description)
         let mut request = Request::builder()
@@ -140,9 +142,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_update_create_graph() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_update_create_graph() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test CREATE GRAPH
         let update = "CREATE GRAPH <http://example.org/newgraph>";
@@ -166,9 +168,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_update_insert_data() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_update_insert_data() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test INSERT DATA to a new graph
         let update = r#"
@@ -199,9 +201,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_update_delete_data_forbidden() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_update_delete_data_forbidden() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test that DELETE DATA is forbidden (read-only for existing graphs)
         let update = r#"
@@ -235,9 +237,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_store_get_all() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_get_all() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test GET /store (get all graphs)
         let mut request = Request::builder()
@@ -269,9 +271,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_store_get_specific_graph() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_get_specific_graph() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test GET /store with graph parameter
         let mut request = Request::builder()
@@ -295,9 +297,9 @@ mod server_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_store_put_new_graph() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_put_new_graph() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test PUT /store with new graph
         let turtle_data = r#"
@@ -325,9 +327,9 @@ ex:Orange ex:hasColor "orange" .
         Ok(())
     }
 
-    #[test]
-    fn test_store_delete_graph() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_delete_graph() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test DELETE endpoint structure
         // (Creating and deleting may fail due to implementation details)
@@ -349,9 +351,9 @@ ex:Orange ex:hasColor "orange" .
         Ok(())
     }
 
-    #[test]
-    fn test_store_head_graph_exists() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_head_graph_exists() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test HEAD /store with existing graph
         let mut request = Request::builder()
@@ -372,9 +374,9 @@ ex:Orange ex:hasColor "orange" .
         Ok(())
     }
 
-    #[test]
-    fn test_store_head_graph_not_exists() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_store_head_graph_not_exists() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test HEAD /store with non-existing graph
         let mut request = Request::builder()
@@ -397,9 +399,9 @@ ex:Orange ex:hasColor "orange" .
         Ok(())
     }
 
-    #[test]
-    fn test_invalid_sparql_query() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_invalid_sparql_query() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test invalid SPARQL query
         let query = "INVALID SPARQL QUERY";
@@ -428,9 +430,9 @@ ex:Orange ex:hasColor "orange" .
         Ok(())
     }
 
-    #[test]
-    fn test_unsupported_media_type() -> anyhow::Result<()> {
-        let (tmp_dir, store) = setup_test_store()?;
+    #[tokio::test]
+    async fn test_unsupported_media_type() -> anyhow::Result<()> {
+        let (tmp_dir, store) = setup_test_store().await?;
 
         // Test PUT with unsupported content type
         let mut request = Request::builder()


### PR DESCRIPTION
Add a new `Enricher` trait allowing for custom filetype-to-RDF implementation

Also updates to the OxRdfConverter to support .gz and .bz2 compressed RDF files